### PR TITLE
Added `allowNamedFunctions` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Add the plugin to the `plugins` section and the rule to the `rules` section in y
     "prefer-arrow-functions/prefer-arrow-functions": [
       "warn",
       {
+        "allowNamedFunctions": false,
         "classPropertiesAllowed": false,
         "disallowPrototype": false,
         "returnStyle": "unchanged",
@@ -45,6 +46,10 @@ Add the plugin to the `plugins` section and the rule to the `rules` section in y
 ```
 
 ## 🤔 Options
+
+### `allowNamedFunctions`
+
+If set to true, the rule won't report named functions such as `function foo() {}`. Anonymous function such as `const foo = function() {}` will still be reported.
 
 ### `classPropertiesAllowed`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_OPTIONS = {
+  allowNamedFunctions: false,
   classPropertiesAllowed: false,
   disallowPrototype: false,
   returnStyle: 'unchanged',

--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -941,7 +941,9 @@ describe('when returnStyle is "explicit"', () => {
 describe('when allowNamedFunctions is true', () => {
   describe("it doesn't report named functions", () => {
     ruleTester.run('lib/rules/prefer-arrow-functions', rule, {
-      valid: validWhenAllowNamedFunctions,
+      valid: validWhenAllowNamedFunctions.map(
+        withOptions({ allowNamedFunctions: true }),
+      ),
       invalid: invalidWhenAllowNamedFunctions
         .map(withOptions({ allowNamedFunctions: true }))
         .map(withErrors([USE_ARROW_WHEN_FUNCTION])),

--- a/src/prefer-arrow-functions.ts
+++ b/src/prefer-arrow-functions.ts
@@ -18,6 +18,7 @@ export default {
       {
         additionalProperties: false,
         properties: {
+          allowNamedFunctions: { type: 'boolean' },
           classPropertiesAllowed: { type: 'boolean' },
           disallowPrototype: { type: 'boolean' },
           returnStyle: {
@@ -37,6 +38,7 @@ export default {
       typeof options[name] !== 'undefined'
         ? options[name]
         : DEFAULT_OPTIONS[name];
+    const allowNamedFunctions = getOption('allowNamedFunctions');
     const singleReturnOnly = getOption('singleReturnOnly');
     const classPropertiesAllowed = getOption('classPropertiesAllowed');
     const disallowPrototype = getOption('disallowPrototype');
@@ -195,10 +197,10 @@ export default {
         });
     };
 
+    const isNamed = (node) => node.id && node.id.name;
+
     const isNamedDefaultExport = (node) =>
-      node.id &&
-      node.id.name &&
-      node.parent.type === 'ExportDefaultDeclaration';
+      isNamed(node) && node.parent.type === 'ExportDefaultDeclaration';
 
     const isSafeTransformation = (node) => {
       return (
@@ -207,6 +209,7 @@ export default {
         !containsSuper(node) &&
         !containsArguments(node) &&
         !containsNewDotTarget(node) &&
+        (!isNamed(node) || !allowNamedFunctions) &&
         (!isPrototypeAssignment(node) || disallowPrototype) &&
         (!singleReturnOnly ||
           (returnsImmediately(node) && !isNamedDefaultExport(node)))


### PR DESCRIPTION
## Description (What)

This PR adds the option to allow (i.e. ignore) all functions that are named and report just anonymous functions

## Justification (Why)

This is an option that I would like to have and it is present in the ts-lint version.

## How Can This Be Tested?

I've added tests.

Closes #18
