### PR TITLE
fix: adds support for assertion functions

### DIFF
--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -100,6 +100,10 @@ const alwaysValid = [
   {
     code: 'function Foo() {if (!new.target) throw "Foo() must be called with new";}',
   },
+  // assertion functions are unavailable in arrow functions
+  {
+    code: 'function foo(val: any): asserts val is string {}',
+  },
 ];
 
 const validWhenSingleReturnOnly = [

--- a/src/prefer-arrow-functions.ts
+++ b/src/prefer-arrow-functions.ts
@@ -86,6 +86,10 @@ export default {
     const getGenericSource = (node) => sourceCode.getText(node.typeParameters);
     const isAsyncFunction = (node) => node.async === true;
     const isGeneratorFunction = (node) => node.generator === true;
+    const isAssertionFunction = (node) =>
+      node.returnType &&
+      node.returnType.typeAnnotation &&
+      node.returnType.typeAnnotation.asserts;
 
     const getReturnType = (node) =>
       node.returnType &&
@@ -205,6 +209,7 @@ export default {
     const isSafeTransformation = (node) => {
       return (
         !isGeneratorFunction(node) &&
+        !isAssertionFunction(node) &&
         !containsThis(node) &&
         !containsSuper(node) &&
         !containsArguments(node) &&


### PR DESCRIPTION
## Description (What)

This PR adds support for assertion functions. [Assertion functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) are not available as arrow functions (see https://github.com/microsoft/TypeScript/issues/34523).

Fixes #22

## Justification (Why)

Because we're not supposed to be converting assertion functions to arrow functions.

## How Can This Be Tested?

1. Checkout this branch
2. Install dependencies
3. Run `yarn test`
4. The new entry in `alwaysValid` (`function foo(val: any): asserts val is string {}`) should pass on the test
