### PR TITLE
fix: adds support for function overloads

### DIFF
--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -113,6 +113,15 @@ const alwaysValid = [
   {
     code: 'const foo = () => { function bar(val: string): void; function bar(val: number): void; function bar(val: string | number): void {} }',
   },
+  {
+    code: 'export function foo(): any;',
+  },
+  {
+    code: 'export function foo(): any; export function foo() {}',
+  },
+  {
+    code: 'export function foo(val: string): void; export function foo(val: number): void; export function foo(val: string | number): void {}',
+  },
 ];
 
 const validWhenSingleReturnOnly = [

--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -100,6 +100,19 @@ const alwaysValid = [
   {
     code: 'function Foo() {if (!new.target) throw "Foo() must be called with new";}',
   },
+  // function overloading is unavailable in arrow functions
+  {
+    code: 'function foo(): any;',
+  },
+  {
+    code: 'function foo(): any; function foo() {}',
+  },
+  {
+    code: 'function foo(val: string): void; function foo(val: number): void; function foo(val: string | number): void {}',
+  },
+  {
+    code: 'const foo = () => { function bar(val: string): void; function bar(val: number): void; function bar(val: string | number): void {} }',
+  },
 ];
 
 const validWhenSingleReturnOnly = [

--- a/src/prefer-arrow-functions.ts
+++ b/src/prefer-arrow-functions.ts
@@ -82,10 +82,27 @@ export default {
     const getFunctionName = (node) =>
       node && node.id && node.id.name ? node.id.name : '';
 
+    const getPreviousNode = (node) => {
+      if (!Array.isArray(node.parent.body)) return null;
+
+      const currentNodeIndex = node.parent.body.indexOf(node);
+      if (currentNodeIndex === 0) return null;
+
+      return node.parent.body[currentNodeIndex - 1];
+    };
+
     const isGenericFunction = (node) => Boolean(node.typeParameters);
     const getGenericSource = (node) => sourceCode.getText(node.typeParameters);
     const isAsyncFunction = (node) => node.async === true;
     const isGeneratorFunction = (node) => node.generator === true;
+    const isOverloadedFunction = (node) => {
+      const previousNode = getPreviousNode(node);
+
+      if (!previousNode) return false;
+      if (previousNode.type === 'TSDeclareFunction') return true;
+
+      return false;
+    };
 
     const getReturnType = (node) =>
       node.returnType &&
@@ -205,6 +222,7 @@ export default {
     const isSafeTransformation = (node) => {
       return (
         !isGeneratorFunction(node) &&
+        !isOverloadedFunction(node) &&
         !containsThis(node) &&
         !containsSuper(node) &&
         !containsArguments(node) &&

--- a/src/prefer-arrow-functions.ts
+++ b/src/prefer-arrow-functions.ts
@@ -83,12 +83,16 @@ export default {
       node && node.id && node.id.name ? node.id.name : '';
 
     const getPreviousNode = (node) => {
+      if (isNamedExport(node)) {
+        node = node.parent;
+      }
+
       if (!Array.isArray(node.parent.body)) return null;
 
-      const currentNodeIndex = node.parent.body.indexOf(node);
-      if (currentNodeIndex === 0) return null;
+      const nodeIndex = node.parent.body.indexOf(node);
+      if (nodeIndex === 0) return null;
 
-      return node.parent.body[currentNodeIndex - 1];
+      return node.parent.body[nodeIndex - 1];
     };
 
     const isGenericFunction = (node) => Boolean(node.typeParameters);
@@ -100,6 +104,11 @@ export default {
 
       if (!previousNode) return false;
       if (previousNode.type === 'TSDeclareFunction') return true;
+      if (
+        previousNode.type === 'ExportNamedDeclaration' &&
+        previousNode.declaration.type === 'TSDeclareFunction'
+      )
+        return true;
 
       return false;
     };
@@ -218,6 +227,9 @@ export default {
 
     const isNamedDefaultExport = (node) =>
       isNamed(node) && node.parent.type === 'ExportDefaultDeclaration';
+
+    const isNamedExport = (node) =>
+      node.parent.type === 'ExportNamedDeclaration';
 
     const isSafeTransformation = (node) => {
       return (


### PR DESCRIPTION
## Description (What)

This PR adds support for function overloads. Function overloads are not supported as arrow functions.

Fixes #17

## Justification (Why)

Because otherwise the plugin will try to convert overloaded functions to arrow functions, breaking its intended behavior.

## How Can This Be Tested?

1. Checkout this branch
2. Install dependencies
3. Run `yarn test`
4. The new entries in `alwaysValid` should pass on the test
