### PR TITLE
fix: don't erase static modifier when auto-fixing static methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage
 dist
 node_modules
+.idea

--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -152,6 +152,9 @@ const validWhenSingleReturnOnly = [
     code: 'class MyClass { async foo(bar) {bar(); return bar()} }',
   },
   {
+    code: 'class MyClass { static foo(bar) {bar(); return bar()} }',
+  },
+  {
     code: 'class MyClass {constructor(foo){this.foo = foo;}}; MyClass.prototype.func = function() {this.foo = "bar";};',
   },
   {
@@ -427,6 +430,11 @@ const invalidAndHasBlockStatement = [
   {
     code: 'class MyClass { render(a, b) { console.log(3); } }',
     output: 'class MyClass { render = (a, b) => { console.log(3); }; }',
+    options: [{ classPropertiesAllowed: true }],
+  },
+  {
+    code: 'class MyClass { static render(a, b) { console.log(3); } }',
+    output: 'class MyClass { static render = (a, b) => { console.log(3); }; }',
     options: [{ classPropertiesAllowed: true }],
   },
   {

--- a/src/prefer-arrow-functions.ts
+++ b/src/prefer-arrow-functions.ts
@@ -237,6 +237,7 @@ export default {
         (node) => {
           const propName = node.key.name;
           const functionNode = node.value;
+          const staticModifier = node.static ? 'static ' : '';
           if (
             isSafeTransformation(functionNode) &&
             (!isWithinClassBody(functionNode) || classPropertiesAllowed)
@@ -246,8 +247,8 @@ export default {
                 fixer.replaceText(
                   node,
                   isWithinClassBody(node)
-                    ? `${propName} = ${writeArrowFunction(functionNode)};`
-                    : `${propName}: ${writeArrowFunction(functionNode)}`,
+                    ? `${staticModifier}${propName} = ${writeArrowFunction(functionNode)};`
+                    : `${staticModifier}${propName}: ${writeArrowFunction(functionNode)}`,
                 ),
               message: getMessage(functionNode),
               node: functionNode,


### PR DESCRIPTION
## Description (What)

Added a check to see if the the function we are changing has the static modifier, and if so, retain it.

Before, it would try to fix methods like:
```ts
class MyClass {
  static async someFunc() {
    return something;
  }
}
```

by doing:

```ts
class MyClass {
  someFunc = async () => something;
}
```

Now it does:
```ts
class MyClass {
  static someFunc = async () => something;
}
```

## Justification (Why)

This is broken, now this is fixed

## How Can This Be Tested?

Unit tests.