### PR TITLE
fix: handle missing case for function overloads

### DIFF
--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -439,6 +439,13 @@ const invalidAndHasSingleReturn = [
     output:
       'var withLoop = async () => async () => { for (i = 0; i < 5; i++) {}}',
   },
+
+  // function overloading - don't mislabel as overload
+  //   export { x as y }; has node.declaration === null - regression test for this case
+  {
+    code: 'export { _foo as bar }; export async function baz() { return false; }',
+    output: 'export { _foo as bar }; export const baz = async () => false;',
+  },
 ];
 
 const invalidAndHasSingleReturnWithMultipleMatches = [

--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -124,6 +124,10 @@ const alwaysValid = [
   {
     code: 'export function foo(val: string): void; export function foo(val: number): void; export function foo(val: string | number): void {}',
   },
+  // export { x }; has node.declaration === null - regression test for this case
+  {
+    code: 'export { foo }; export function bar(val: number): void; export function bar(val: string | number): void {}',
+  },
 ];
 
 const validWhenSingleReturnOnly = [
@@ -441,10 +445,10 @@ const invalidAndHasSingleReturn = [
   },
 
   // function overloading - don't mislabel as overload
-  //   export { x as y }; has node.declaration === null - regression test for this case
+  //   export { x }; has node.declaration === null - regression test for this case
   {
-    code: 'export { _foo as bar }; export async function baz() { return false; }',
-    output: 'export { _foo as bar }; export const baz = async () => false;',
+    code: 'export { foo }; export async function bar() { return false; }',
+    output: 'export { foo }; export const bar = async () => false;',
   },
 ];
 

--- a/src/prefer-arrow-functions.ts
+++ b/src/prefer-arrow-functions.ts
@@ -9,7 +9,7 @@ import {
 export default {
   meta: {
     docs: {
-      category: 'emcascript6',
+      category: 'ecmascript6',
       description: 'prefer arrow functions',
       recommended: false,
     },
@@ -110,7 +110,7 @@ export default {
       if (previousNode.type === 'TSDeclareFunction') return true;
       if (
         previousNode.type === 'ExportNamedDeclaration' &&
-        previousNode.declaration.type === 'TSDeclareFunction'
+        previousNode.declaration?.type === 'TSDeclareFunction'
       )
         return true;
 


### PR DESCRIPTION
## Description (What)

3.3.1 throws an error on this case:

```ts
export { _foo as bar };

export async function baz() { return false; }
```

because when it checks the `baz()` line, it gets the previous node, and assumes that `node.declaration` is non-null. In this case (`export { _foo as bar };`), it is. We can just return false in this case since it is not an overload.

The error:
```
Oops! Something went wrong! :(
ESLint: 8.48.0
TypeError: Cannot read properties of null (reading 'type')
Occurred while linting <PATH_TO_FILE>:<LINE>
Rule: "prefer-arrow-functions/prefer-arrow-functions"
    at isOverloadedFunction (<PATH_TO_REPO>/node_modules/eslint-plugin-prefer-arrow-functions/dist/prefer-arrow-functions.js:99:42)
    at isSafeTransformation (<PATH_TO_REPO>/node_modules/eslint-plugin-prefer-arrow-functions/dist/prefer-arrow-functions.js:201:18)
    at FunctionDeclaration[parent.type!="ExportDefaultDeclaration"] (<PATH_TO_REPO>/node_modules/eslint-plugin-prefer-arrow-functions/dist/prefer-arrow-functions.js:273:21)
    at ruleErrorHandler (<PATH_TO_REPO>/node_modules/eslint/lib/linter/linter.js:1050:28)
    at <PATH_TO_REPO>/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (<PATH_TO_REPO>/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (<PATH_TO_REPO>/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (<PATH_TO_REPO>/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
    at NodeEventGenerator.enterNode (<PATH_TO_REPO>/node_modules/eslint/lib/linter/node-event-generator.js:340:14)

```

## Justification (Why)

3.3.1 currently breaks when a module like above exists in a codebase.

## How Can This Be Tested?

I added a unit test.

You can run eslint against a file with the contents above and confirm that it breaks before this change, and works after.