### PR TITLE
fix: adjusts fix for generic type arguments on TSX files 

### DIFF
--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -813,6 +813,18 @@ const invalidWhenAllowNamedFunctions = [
   },
 ];
 
+const validAndFileIsTSX = [
+  {
+    code: 'const Component = <T,>() => <div>test</div>;',
+  },
+  {
+    code: 'const Component = <T,>() => <div>test</div>;',
+  },
+  {
+    code: 'const Component = <T,U>() => <div>test</div>;',
+  },
+];
+
 const invalidAndFileIsTSX = [
   {
     code: 'function Component<T>() { return <div>test</div> }',
@@ -1026,7 +1038,7 @@ describe('when allowNamedFunctions is true', () => {
 describe('when file is TSX', () => {
   describe('it properly fixes generic type arguments', () => {
     ruleTester.run('lib/rules/prefer-arrow-functions', rule, {
-      valid: [],
+      valid: validAndFileIsTSX.map(withTSX()),
       invalid: invalidAndFileIsTSX
         .map(withTSX())
         .map(withErrors([USE_ARROW_WHEN_FUNCTION])),

--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -813,6 +813,21 @@ const invalidWhenAllowNamedFunctions = [
   },
 ];
 
+const invalidAndFileIsTSX = [
+  {
+    code: 'function Component<T>() { return <div>test</div> }',
+    output: 'const Component = <T,>() => <div>test</div>;',
+  },
+  {
+    code: 'function Component<T,>() { return <div>test</div> }',
+    output: 'const Component = <T,>() => <div>test</div>;',
+  },
+  {
+    code: 'function Component<T,U>() { return <div>test</div> }',
+    output: 'const Component = <T,U>() => <div>test</div>;',
+  },
+];
+
 const ruleTester = new RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
   parserOptions: {
@@ -830,6 +845,16 @@ const withOptions = (extraOptions) => (object) => ({
 const withErrors = (errors) => (object) => ({
   ...object,
   errors,
+});
+
+const withTSX = () => (object) => ({
+  ...object,
+  filename: '/some/path/Component.tsx',
+  parserOptions: {
+    ecmaFeatures: { jsx: true },
+    ecmaVersion: 8,
+    sourceType: 'module',
+  },
 });
 
 describe('when function is valid, or cannot be converted to an arrow function', () => {
@@ -993,6 +1018,17 @@ describe('when allowNamedFunctions is true', () => {
       ),
       invalid: invalidWhenAllowNamedFunctions
         .map(withOptions({ allowNamedFunctions: true }))
+        .map(withErrors([USE_ARROW_WHEN_FUNCTION])),
+    });
+  });
+});
+
+describe('when file is TSX', () => {
+  describe('it properly fixes generic type arguments', () => {
+    ruleTester.run('lib/rules/prefer-arrow-functions', rule, {
+      valid: [],
+      invalid: invalidAndFileIsTSX
+        .map(withTSX())
         .map(withErrors([USE_ARROW_WHEN_FUNCTION])),
     });
   });

--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -818,9 +818,6 @@ const validAndFileIsTSX = [
     code: 'const Component = <T,>() => <div>test</div>;',
   },
   {
-    code: 'const Component = <T,>() => <div>test</div>;',
-  },
-  {
     code: 'const Component = <T,U>() => <div>test</div>;',
   },
 ];

--- a/src/prefer-arrow-functions.ts
+++ b/src/prefer-arrow-functions.ts
@@ -38,12 +38,17 @@ export default {
       typeof options[name] !== 'undefined'
         ? options[name]
         : DEFAULT_OPTIONS[name];
+
     const allowNamedFunctions = getOption('allowNamedFunctions');
     const singleReturnOnly = getOption('singleReturnOnly');
     const classPropertiesAllowed = getOption('classPropertiesAllowed');
     const disallowPrototype = getOption('disallowPrototype');
     const returnStyle = getOption('returnStyle');
+
     const sourceCode = context.getSourceCode();
+
+    const filename = context.getPhysicalFilename();
+    const isTSX = filename?.endsWith('.tsx');
 
     const isBlockStatementWithSingleReturn = (node) => {
       return (
@@ -96,7 +101,15 @@ export default {
     };
 
     const isGenericFunction = (node) => Boolean(node.typeParameters);
-    const getGenericSource = (node) => sourceCode.getText(node.typeParameters);
+    const getGenericSource = (node) => {
+      const genericSource = sourceCode.getText(node.typeParameters);
+      if (!isTSX) return genericSource;
+
+      const genericParameterCount = node.typeParameters?.params?.length || 0;
+      if (genericParameterCount === 1)
+        return `<${node.typeParameters.params[0].name.name},>`;
+      return genericSource;
+    };
     const isAsyncFunction = (node) => node.async === true;
     const isGeneratorFunction = (node) => node.generator === true;
     const isAssertionFunction = (node) =>


### PR DESCRIPTION
## Description (What)

This PR implements an adjustment on the auto=fixer when transforming generic TSX components with one type argument.

Fixes #27

## Justification (Why)

Otherwise, the auto-fix will generate invalid TSX syntax.

## How Can This Be Tested?

I added unit tests, but I used a few React + TypeScript codebases to test this on, plus unit tests.
