### PR TITLE
#29 Don't flag constructors when this is not present

### DIFF
--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -846,7 +846,9 @@ describe('when function is valid, or cannot be converted to an arrow function', 
     ruleTester.run('lib/rules/prefer-arrow-functions', rule, {
       valid: [
         ...alwaysValid,
-        ...validWhenClassPropertiesAllowed.map(withOptions({ classPropertiesAllowed: true }))
+        ...validWhenClassPropertiesAllowed.map(
+          withOptions({ classPropertiesAllowed: true }),
+        ),
       ],
       invalid: [],
     });

--- a/src/prefer-arrow-functions.spec.ts
+++ b/src/prefer-arrow-functions.spec.ts
@@ -57,6 +57,9 @@ const alwaysValid = [
     code: 'class obj {constructor(foo){this.foo = foo;}}; obj.prototype = {func: function() {}};',
   },
   {
+    code: 'class obj {constructor(private readonly foo: number){}};',
+  },
+  {
     code: 'var foo = function() { return this.bar; };',
   },
   {
@@ -123,6 +126,12 @@ const alwaysValid = [
   },
   {
     code: 'export function foo(val: string): void; export function foo(val: number): void; export function foo(val: string | number): void {}',
+  },
+];
+
+const validWhenClassPropertiesAllowed = [
+  {
+    code: 'class obj {constructor(private readonly foo: number){}};',
   },
 ];
 
@@ -835,7 +844,10 @@ const withErrors = (errors) => (object) => ({
 describe('when function is valid, or cannot be converted to an arrow function', () => {
   describe('it considers the function valid', () => {
     ruleTester.run('lib/rules/prefer-arrow-functions', rule, {
-      valid: alwaysValid,
+      valid: [
+        ...alwaysValid,
+        ...validWhenClassPropertiesAllowed.map(withOptions({ classPropertiesAllowed: true }))
+      ],
       invalid: [],
     });
   });

--- a/src/prefer-arrow-functions.ts
+++ b/src/prefer-arrow-functions.ts
@@ -265,7 +265,7 @@ export default {
           });
         }
       },
-      ':matches(ClassProperty, MethodDefinition, Property)[key.name][value.type="FunctionExpression"][kind!=/^(get|set)$/]':
+      ':matches(ClassProperty, MethodDefinition, Property)[key.name][value.type="FunctionExpression"][kind!=/^(get|set|constructor)$/]':
         (node) => {
           const propName = node.key.name;
           const functionNode = node.value;


### PR DESCRIPTION
## Description (What)

Fixes #29.

Constructors like this:
```ts
class Obj {
  constructor(private readonly foo: number) {}
};
```

don't have `this`, so they get incorrectly flagged by the plugin. We should be sure to exclude all constructors from this rule.

## Justification (Why)

Because constructors cannot be arrow functions.

## How Can This Be Tested?

See tests, you can revert the fix to demonstrate that this change works.