### PR TITLE
Fix allowed versions in `eslint` `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "peerDependencies": {
-    "eslint": "9.17.0"
+    "eslint": ">=9.17.0"
   },
   "repository": "JamieMason/eslint-plugin-prefer-arrow-functions",
   "scripts": {


### PR DESCRIPTION
## Description (What)

Fixes #51.

## Justification (Why)

See #51.

## How Can This Be Tested?

Install this plugin with ESLint `9.18.0`.