### PR TITLE
Fixed imports

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/types';
-import { RuleContext } from '@typescript-eslint/utils/ts-eslint';
+import { TSESLint } from '@typescript-eslint/utils';
 
 export type AnyFunctionBody = TSESTree.BlockStatement | TSESTree.Expression;
 export type AnyFunction = TSESTree.FunctionDeclaration | TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression;
@@ -13,7 +13,7 @@ export type Options = [ActualOptions];
 export interface Scope {
   isTsx: boolean;
   options: ActualOptions;
-  sourceCode: RuleContext<MessageId, Options>['sourceCode'];
+  sourceCode: TSESLint.RuleContext<MessageId, Options>['sourceCode'];
 }
 
 export interface ActualOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,4 +13,4 @@ const plugin: TSESLint.FlatConfig.Plugin = {
   },
 };
 
-export default plugin;
+export const { meta, rules } = plugin;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "module": "NodeNext",
+    "module": "CommonJS",
     "outDir": "dist",
     "resolveJsonModule": true,
     "rootDir": "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "module": "CommonJS",
+    "module": "NodeNext",
     "outDir": "dist",
     "resolveJsonModule": true,
     "rootDir": "src",


### PR DESCRIPTION
## Description (What)

Closes #50.

I fixed one import that was touching internal things. On top of that, CommonJS style plugins shouldn't export one variable called `default` (ESM ones should), but the individual keys should. In the future, I'd recommend switching to ESM.

## Justification (Why)

Because it's broken :D

## How Can This Be Tested?

Use in a 3rd party project (I have tested this)
