### PR TITLE
docs(config): add the documentation for the Flat configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,80 @@ npm install --save-dev eslint eslint-plugin-prefer-arrow-functions
 
 ## Configuration
 
-Add the plugin to the `plugins` section and the rule to the `rules` section in your .eslintrc. The default values for options are listed in this example.
+### Flat
+
+For ESLint 9 and above.
+
+`eslint.config.mjs`:
+
+```js
+// Your file header
+
+import pluginJs from "@eslint/js";
+
+// Your imports
+
+import preferArrowFunctions from "eslint-plugin-prefer-arrow-functions";
+
+// Your imports
+
+
+export default [
+
+  // Presets of your plugins
+
+  // Or pluginJs.configs.recommended,
+  pluginJs.configs.all, {
+
+    // Your settings
+
+    plugins: {
+
+      // Your plugins
+
+      "prefer-arrow-functions": preferArrowFunctions,
+
+      // Your plugins
+
+    },
+
+    // Your settings
+
+    rules: {
+
+      // Your rules
+
+      "prefer-arrow-functions/prefer-arrow-functions": [
+
+        "warn",
+
+        {
+          "allowedNames": [],
+          "allowNamedFunctions": false,
+          "allowObjectProperties": false,
+          "classPropertiesAllowed": false,
+          "disallowPrototype": false,
+          "returnStyle": "unchanged",
+          "singleReturnOnly": false
+        }
+
+      ],
+
+      // Your rules
+
+    }
+
+  }
+
+];
+
+```
+
+### Legacy
+
+For ESLint 8 and below.
+
+Add the plugin to the `plugins` section and the rule to the `rules` section in your `.eslintrc`. The default values for options are listed in this example.
 
 ```json
 {


### PR DESCRIPTION
## 1. Description (What)

I added to the plugin documentation information, how users can configure eslint-plugin-prefer-arrow-functions for the Flat configuration that required for ESLint 9.

## 2. Justification (Why)

Information about the basic plugin usage must be in the documentation. Users shouldn’t search it in comments for issues and pull requests and/or on GitHub.

Thanks.