### PR TITLE
feat: add shared config `all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,19 @@ npm install --save-dev eslint eslint-plugin-prefer-arrow-functions
 
 ### Flat
 
-For ESLint 9 and above.
+For ESLint 9 and above, use the shared config `all` in `eslint.config.mjs`:
 
-`eslint.config.mjs`:
+```js
+import pluginJs from '@eslint/js';
+import preferArrowFunctions from 'eslint-plugin-prefer-arrow-functions';
+
+export default [
+  pluginJs.configs.all,
+  preferArrowFunctions.configs.all,
+];
+```
+
+Or configure the rule(s) on your own:
 
 ```js
 import pluginJs from '@eslint/js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,14 @@ const plugin: TSESLint.FlatConfig.Plugin = {
   rules,
 };
 
+export const configs: TSESLint.FlatConfig.SharedConfigs = {
+  all: {
+    plugins: { 'prefer-arrow-functions': plugin },
+    rules: {
+      'prefer-arrow-functions/prefer-arrow-functions': 'warn',
+    },
+  },
+};
+plugin.configs = configs;
+
 export default plugin;


### PR DESCRIPTION
Fix #57.

This adds a basic shared config `all` containing the single rule with level `warn` (as in the examples) and using its default option values.

I also thought about adding `recommended` as well but it would be an exact copy of `all` for now.
I'd rather suggest to add it only later when further rules are added to the plugin.