### PR TITLE
fix: do not convert functions where first parameter is `this`

### DIFF
--- a/src/guard.ts
+++ b/src/guard.ts
@@ -161,32 +161,18 @@ export class Guard {
 
     const [firstParam] = fn.params;
 
-    const getIdentifier = (param: TSESTree.Parameter): TSESTree.Identifier | null => {
-      if (param.type === AST_NODE_TYPES.Identifier) {
-        return param;
-      }
+    if (firstParam.type === AST_NODE_TYPES.Identifier) {
+      return firstParam.name === 'this';
+    }
 
-      if (param.type === AST_NODE_TYPES.AssignmentPattern && param.left.type === AST_NODE_TYPES.Identifier) {
-        return param.left;
-      }
+    if (
+      firstParam.type === AST_NODE_TYPES.TSParameterProperty &&
+      firstParam.parameter.type === AST_NODE_TYPES.Identifier
+    ) {
+      return firstParam.parameter.name === 'this';
+    }
 
-      if (param.type === AST_NODE_TYPES.RestElement && param.argument.type === AST_NODE_TYPES.Identifier) {
-        return param.argument;
-      }
-
-      if (
-        param.type === AST_NODE_TYPES.TSParameterProperty &&
-        param.parameter.type === AST_NODE_TYPES.Identifier
-      ) {
-        return param.parameter;
-      }
-
-      return null;
-    };
-
-    const identifier = getIdentifier(firstParam);
-
-    return identifier?.name === 'this';
+    return false;
   }
 
   containsTokenSequence(sequence: [string, string][], node: TSESTree.Node): boolean {

--- a/test/rule.spec.ts
+++ b/test/rule.spec.ts
@@ -143,6 +143,12 @@ describe('when function is already an arrow function, or cannot be converted to 
         {
           code: 'function Foo() {if (!new.target) throw "Foo() must be called with new";}',
         },
+        {
+          code: 'function withThis(this: HTMLElement, event: Event) { return event.type; }',
+        },
+        {
+          code: 'const withThis = function(this: void, value: number) { return value; };',
+        },
         // assertion functions are unavailable in arrow functions
         {
           code: 'function foo(val: any): asserts val is string {}',


### PR DESCRIPTION
## Description (What)

Fixes #63 by preventing conversion of functions when the first parameter is `this`

## Justification (Why)

Some custom userland functions that are ultimately passed back into a library are sometimes required to be instance methods with `this` declared for correct argument types, regardless of whether `this` is needed by the function body. One such example is fastify's `app.setErrorHandler(fn)` (5.1.0)

## How Can This Be Tested?

Tests were added
