### PR TITLE
fix: export ESLint-native types for defineConfig() compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/utils';
+import type { ESLint, Linter, Rule } from 'eslint';
 import { preferArrowFunctions } from './rule';
 
 const { name, version } =
@@ -6,18 +6,41 @@ const { name, version } =
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   require('../package.json') as typeof import('../package.json');
 
+/**
+ * Bridges a TSESLint rule to an ESLint-native Rule.RuleModule.
+ *
+ * TSESLint rules use TypeScript-enhanced AST types (TSESTree) internally
+ * but are fully compatible with ESLint's native types at runtime.
+ * The type systems are structurally incompatible due to TSESTree extending
+ * ESTree's node unions with TypeScript-specific AST node types.
+ * See: https://github.com/typescript-eslint/typescript-eslint/issues/9724
+ */
+function toRuleModule(rule: typeof preferArrowFunctions): Rule.RuleModule {
+  return {
+    // @ts-expect-error — TSESLint's RuleMetaData.deprecated is 'boolean | DeprecatedInfo'
+    // which is wider than ESLint's 'boolean'. Compatible at runtime.
+    meta: rule.meta,
+    create(context): Rule.RuleListener {
+      // @ts-expect-error — TSESLint and ESLint define RuleContext/RuleListener with
+      // structurally incompatible AST types (TSESTree vs ESTree) that are identical
+      // at runtime. See: https://github.com/typescript-eslint/typescript-eslint/issues/9724
+      return rule.create(context);
+    },
+  };
+}
+
 export const meta = { name, version };
 
-export const rules: Record<string, TSESLint.LooseRuleDefinition> = {
-  'prefer-arrow-functions': preferArrowFunctions,
+export const rules: Record<string, Rule.RuleModule> = {
+  'prefer-arrow-functions': toRuleModule(preferArrowFunctions),
 };
 
-const plugin: TSESLint.FlatConfig.Plugin = {
+const plugin: ESLint.Plugin = {
   meta,
   rules,
 };
 
-export const configs: TSESLint.FlatConfig.SharedConfigs = {
+export const configs: Record<string, Linter.Config> = {
   all: {
     plugins: { 'prefer-arrow-functions': plugin },
     rules: {


### PR DESCRIPTION
## Summary

- Fixes type incompatibility when using the plugin with ESLint's `defineConfig()` and strict TypeScript type-checking
- Replaces exported `TSESLint.FlatConfig.Plugin` / `SharedConfigs` types with ESLint-native `ESLint.Plugin`, `Rule.RuleModule`, and `Linter.Config`
- Adds a `toRuleModule` bridge function that adapts the internal TSESLint rule without type casts

## Problem

When consumers assign this plugin to a `plugins` object in ESLint's `defineConfig()`, TypeScript produces a **TS2322** error:

```ts
import preferArrowFunctions from 'eslint-plugin-prefer-arrow-functions';

export default defineConfig([
  {
    plugins: {
      // TS2322: Type 'Plugin' is not assignable to type 'Plugin'.
      'prefer-arrow-functions': preferArrowFunctions,
    },
  },
]);
```

**Root cause:** `@typescript-eslint/utils`'s `FlatConfig.LanguageOptions` is missing an index signature (`[key: string]: unknown`) that `@eslint/core`'s `LanguageOptions` requires. This makes `TSESLint.FlatConfig.Plugin` incompatible with ESLint's native `Plugin` type. Tracked upstream: https://github.com/typescript-eslint/typescript-eslint/issues/9724

## Solution

The exported types now use ESLint's native type system exclusively:

| Export | Before | After |
|--------|--------|-------|
| `default` | `TSESLint.FlatConfig.Plugin` | `ESLint.Plugin` |
| `rules` | `Record<string, TSESLint.LooseRuleDefinition>` | `Record<string, Rule.RuleModule>` |
| `configs` | `TSESLint.FlatConfig.SharedConfigs` | `Record<string, Linter.Config>` |

A `toRuleModule` bridge function adapts the internal TSESLint-typed rule to `Rule.RuleModule`. It uses two `@ts-expect-error` directives (no `as` casts) that will **automatically surface as errors** when the upstream issue is fixed, prompting their removal.

Internal rule code is unchanged — it continues using TSESTree types for AST analysis.

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 506 tests pass
- [x] Built `dist/index.d.ts` exports only ESLint-native types (no TSESLint leakage)
- [ ] Verify in a consuming project that `defineConfig({ plugins: { 'prefer-arrow-functions': plugin } })` compiles without TS errors